### PR TITLE
fix SyntaxWarnings during install / build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,21 +20,26 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install
       run: |
         python -m pip install --upgrade pip
-        pip install -e .
+        pip install .
         pip install pytest
+
     - name: Run tests via original runner
       run: |
         make test-unittest
+
     - name: Run tests via pytest
       run: |
         make test-pytest
+
     - name: Check for file changes
       run: |
         make check-clean

--- a/gpkit/breakdowns.py
+++ b/gpkit/breakdowns.py
@@ -451,7 +451,7 @@ def crawl(
                 if vk.units:
                     units *= vk.units ** mon.exp[vk]
             subhmap = NomialMap({exp: 1})
-            subhmap.units = None if units is 1 else units
+            subhmap.units = None if (type(units) is int and units == 1) else units
             freemon = Monomial(subhmap)
             factor = mon / freemon  # autoconvert...
             if (

--- a/gpkit/nomials/math.py
+++ b/gpkit/nomials/math.py
@@ -623,13 +623,13 @@ class SignomialInequality(ScalarSingleEquationConstraint):
         (siglt0,) = self.unsubbed
         siglt0 = siglt0.sub(substitutions, require_positive=False)
         posy, negy = siglt0.posy_negy()
-        if posy is 0:  # pylint: disable=literal-comparison
+        if type(posy) is int and posy == 0:
             print(
                 "Warning: SignomialConstraint %s became the tautological"
                 " constraint 0 <= %s after substitution." % (self, negy)
             )
             return []
-        if negy is 0:  # pylint: disable=literal-comparison
+        if type(negy) is int and negy == 0:
             raise ValueError(
                 "%s became the infeasible constraint %s <= 0"
                 " after substitution." % (self, posy)

--- a/gpkit/small_scripts.py
+++ b/gpkit/small_scripts.py
@@ -72,9 +72,10 @@ def splitsweep(sub):
     "Splits a substitution into (is_sweepvar, sweepval)"
     try:
         sweep, value = sub
-        if type(sweep) is str and sweep == "sweep" and (
-            isinstance(value, Iterable)
-            or hasattr(value, "__call__")
+        if (
+            type(sweep) is str
+            and sweep == "sweep"
+            and (isinstance(value, Iterable) or hasattr(value, "__call__"))
         ):
             return True, value
     except (TypeError, ValueError):

--- a/gpkit/small_scripts.py
+++ b/gpkit/small_scripts.py
@@ -72,8 +72,8 @@ def splitsweep(sub):
     "Splits a substitution into (is_sweepvar, sweepval)"
     try:
         sweep, value = sub
-        if sweep is "sweep" and (
-            isinstance(value, Iterable)  # pylint: disable=literal-comparison
+        if type(sweep) is str and sweep == "sweep" and (
+            isinstance(value, Iterable)
             or hasattr(value, "__call__")
         ):
             return True, value


### PR DESCRIPTION
Eliminate several instances of `SyntaxWarning: "is" with a literal. Did you mean "=="?`