### PR TITLE
add resolve and clean logic to VarSet

### DIFF
--- a/gpkit/tests/t_varset.py
+++ b/gpkit/tests/t_varset.py
@@ -39,6 +39,27 @@ def test_keys():
     assert vs.keys(vv[0]) == set()
     assert vs.keys("y") == {y.key}
 
+def test_resolve():
+    x = Variable("x", "m")
+    x2 = Variable("x", "ft")
+    z = Variable("z")
+    vv = VectorVariable(4, "t")
+    vs = VarSet({x.key, x2.key, z.key, vv.key})
+    assert vs.resolve(vv) == vv.key
+    assert vs.resolve(vv.key) == vv.key
+    assert vs.resolve(z) == z.key
+    assert vs.resolve("t") == vv.key
+    with pytest.raises(KeyError):
+        vs.resolve("x")
+    with pytest.raises(KeyError):
+        vs.resolve("y")
+
+def test_clean():
+    x = Variable("x")
+    y = Variable("y")
+    vs = VarSet({x.key, y.key})
+    assert vs.clean({"x": 5, "y": 2}) == {x.key: 5, y.key: 2}
+
 
 # ---------- vector handling --------------------------------------------------
 def test_register_vector():

--- a/gpkit/tests/t_varset.py
+++ b/gpkit/tests/t_varset.py
@@ -39,6 +39,7 @@ def test_keys():
     assert vs.keys(vv[0]) == set()
     assert vs.keys("y") == {y.key}
 
+
 def test_resolve():
     x = Variable("x", "m")
     x2 = Variable("x", "ft")
@@ -53,6 +54,7 @@ def test_resolve():
         vs.resolve("x")
     with pytest.raises(KeyError):
         vs.resolve("y")
+
 
 def test_clean():
     x = Variable("x")

--- a/gpkit/varmap.py
+++ b/gpkit/varmap.py
@@ -105,6 +105,22 @@ class VarSet(set):
                 out.add(k)
         return out
 
+    def resolve(self, key):
+        "Return *one* canonical VarKey for (Variable, str, or veckey) key"
+        if hasattr(key, "key"):
+            return key.key
+        keys = self.by_name(key)
+        if not len(keys):
+            raise KeyError(f"{key} not present")
+        elif len(keys) > 1:
+            raise KeyError(f"{key} refers to multiple keys {keys}")
+        (out,) = keys
+        return out
+
+    def clean(self, mapping):
+        "return a *new dict* with all keys in mapping resolved."
+        return {self.resolve(k): v for k, v in mapping.items()}
+
     def update(self, keys):
         for k in keys:
             self.add(k)

--- a/gpkit/varmap.py
+++ b/gpkit/varmap.py
@@ -119,9 +119,9 @@ class VarSet(set):
 
     def _register_key(self, key):
         "adds the key to _by_name and, if applicable, _by_vec"
-        if not hasattr(key, "name"):
+        name = getattr(key, "name", None)
+        if name is None:
             raise TypeError("VarSet keys must be VarKey instances")
-        name = key.name
         if name not in self._by_name:
             self._by_name[name] = set()
         idx = getattr(key, "idx", None)


### PR DESCRIPTION
move varkey cleaning logic to VarSet via `resolve` and `clean` methods. Needed for downstream improvements.