### PR TITLE
untangle substitution, sweeps, and linkedsweeps

### DIFF
--- a/docs/source/examples/evaluated_fixed_variables.py
+++ b/docs/source/examples/evaluated_fixed_variables.py
@@ -13,7 +13,6 @@ sol = m.solve(verbosity=0)
 # assert sol["variables"][t_night] == 12
 # floating point roundoff errors running with pytest
 
-sweep = {t_day: [8, 12, 16]}
-sol = m.solve(verbosity=0, sweep=sweep)
+sol = m.sweep({t_day: [8, 12, 16]}, verbosity=0)
 # assert (sol["variables"][t_night] == [16, 12, 8]).all()
 # floating point roundoff errors running with pytest

--- a/docs/source/examples/evaluated_fixed_variables.py
+++ b/docs/source/examples/evaluated_fixed_variables.py
@@ -13,8 +13,7 @@ sol = m.solve(verbosity=0)
 # assert sol["variables"][t_night] == 12
 # floating point roundoff errors running with pytest
 
-# call substitutions
-m.substitutions.update({t_day: ("sweep", [8, 12, 16])})
-sol = m.solve(verbosity=0)
+sweep = {t_day: [8, 12, 16]}
+sol = m.solve(verbosity=0, sweep=sweep)
 # assert (sol["variables"][t_night] == [16, 12, 8]).all()
 # floating point roundoff errors running with pytest

--- a/docs/source/examples/issue_1513.py
+++ b/docs/source/examples/issue_1513.py
@@ -97,11 +97,7 @@ class Cake(Model):
 
 
 m = Cake()
-m.substitutions.update(
-    {
-        "y": ("sweep", [1, 2, 3]),
-        "z": lambda v: np.array(v["y"]) ** 2,
-    }
-)
-sol = m.solve(verbosity=0)
+m.substitutions.update({"z": lambda v: np.array(v["y"]) ** 2})
+sweep = {"y": [1, 2, 3]}
+sol = m.solve(verbosity=0, sweep=sweep)
 print(sol.table())

--- a/docs/source/examples/issue_1513.py
+++ b/docs/source/examples/issue_1513.py
@@ -98,6 +98,5 @@ class Cake(Model):
 
 m = Cake()
 m.substitutions.update({"z": lambda v: np.array(v["y"]) ** 2})
-sweep = {"y": [1, 2, 3]}
-sol = m.solve(verbosity=0, sweep=sweep)
+sol = m.sweep({"y": [[1, 2, 3]]}, verbosity=0)
 print(sol.table())

--- a/docs/source/examples/migp.py
+++ b/docs/source/examples/migp.py
@@ -5,9 +5,9 @@ import numpy as np
 from gpkit import Model, Variable
 
 x = Variable("x", choices=range(1, 4))
-num = Variable("numerator", np.linspace(0.5, 7, 11))
+num = Variable("numerator")
 
 m = Model(x + num / x)
-sol = m.solve(verbosity=0)
+sol = m.solve(verbosity=0, sweep={num: np.linspace(0.5, 7, 11)})
 
 print(sol.table())

--- a/docs/source/examples/migp.py
+++ b/docs/source/examples/migp.py
@@ -8,6 +8,6 @@ x = Variable("x", choices=range(1, 4))
 num = Variable("numerator")
 
 m = Model(x + num / x)
-sol = m.solve(verbosity=0, sweep={num: np.linspace(0.5, 7, 11)})
+sol = m.sweep({num: np.linspace(0.5, 7, 11)}, verbosity=0)
 
 print(sol.table())

--- a/docs/source/examples/simpleflight.py
+++ b/docs/source/examples/simpleflight.py
@@ -71,11 +71,10 @@ print(sol.diff("solution.pkl"))
 print("SWEEP\n=====")
 N = 2
 sweeps = {
-    V_min: ("sweep", np.linspace(20, 25, N)),
-    V: ("sweep", np.linspace(45, 55, N)),
+    V_min: np.linspace(20, 25, N),
+    V: np.linspace(45, 55, N),
 }
-m.substitutions.update(sweeps)
-sweepsol = m.solve(verbosity=0)
+sweepsol = m.solve(verbosity=0, sweep=sweeps)
 print(sweepsol.summary())
 with open("solution.pkl", "rb") as fil:
     sol_loaded = pickle.load(fil)

--- a/docs/source/examples/simpleflight.py
+++ b/docs/source/examples/simpleflight.py
@@ -69,12 +69,11 @@ sol.save_compressed("solution.pgz")
 print(sol.diff("solution.pkl"))
 
 print("SWEEP\n=====")
-N = 2
 sweeps = {
-    V_min: np.linspace(20, 25, N),
-    V: np.linspace(45, 55, N),
+    V_min: [20.0, 20, 25, 25],
+    V: [45.0, 55, 45, 55],
 }
-sweepsol = m.solve(verbosity=0, sweep=sweeps)
+sweepsol = m.sweep(sweeps, verbosity=0)
 print(sweepsol.summary())
 with open("solution.pkl", "rb") as fil:
     sol_loaded = pickle.load(fil)

--- a/docs/source/examples/sp_to_gp_sweep.py
+++ b/docs/source/examples/sp_to_gp_sweep.py
@@ -113,8 +113,6 @@ def SimPleAC():
 
 
 sa = SimPleAC()
-sa.substitutions.update(
-    {"V_f_wing": ("sweep", np.linspace(0.1, 0.5, 3)), "V_f_fuse": 0.5}
-)
-sol = sa.solve(verbosity=0)
+sa.substitutions.update({"V_f_fuse": 0.5})
+sol = sa.solve(verbosity=0, sweep={"V_f_wing": np.linspace(0.1, 0.5, 3)})
 print(sol.summary())

--- a/docs/source/examples/sp_to_gp_sweep.py
+++ b/docs/source/examples/sp_to_gp_sweep.py
@@ -114,5 +114,5 @@ def SimPleAC():
 
 sa = SimPleAC()
 sa.substitutions.update({"V_f_fuse": 0.5})
-sol = sa.solve(verbosity=0, sweep={"V_f_wing": np.linspace(0.1, 0.5, 3)})
+sol = sa.sweep({"V_f_wing": np.linspace(0.1, 0.5, 3)}, verbosity=0)
 print(sol.summary())

--- a/gpkit/__init__.py
+++ b/gpkit/__init__.py
@@ -1,6 +1,6 @@
 "GP and SP modeling package"
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 from .build import build
 from .constraints.set import ConstraintSet

--- a/gpkit/constraints/relax.py
+++ b/gpkit/constraints/relax.py
@@ -2,7 +2,8 @@
 """Models for assessing primal feasibility"""
 
 from ..globals import NamedVariables, SignomialsEnabled
-from ..nomials import NomialArray, Variable, VectorVariable, parse_subs
+from ..nomials import NomialArray, Variable, VectorVariable
+from ..nomials.substitution import parse_linked, parse_subs
 from ..util.small_scripts import appendsolwarning, initsolwarning, mag
 from ..varmap import VarMap
 from .set import ConstraintSet
@@ -191,7 +192,8 @@ class ConstantsRelaxed(ConstraintSet):
         if not isinstance(constraints, ConstraintSet):
             constraints = ConstraintSet(constraints)
         substitutions = VarMap(constraints.substitutions)
-        constants, _, linked = parse_subs(constraints.vks, substitutions)
+        constants = parse_subs(constraints.vks, substitutions)
+        linked = parse_linked(constraints.vks, substitutions)
         if linked:
             kdc = VarMap(constants)
             constrained_varkeys = constraints.constrained_varkeys()

--- a/gpkit/constraints/set.py
+++ b/gpkit/constraints/set.py
@@ -84,7 +84,7 @@ class ConstraintSet(list, ReprMixin):  # pylint: disable=too-many-instance-attri
         elif isinstance(constraints, ConstraintSet):
             constraints = [constraints]  # put it one level down
         list.__init__(self, constraints)
-        self.vks = set(self.unique_varkeys)
+        self.vks = VarSet(self.unique_varkeys)
         self.substitutions = VarMap(
             {k: k.value for k in self.unique_varkeys if "value" in k.descr}
         )

--- a/gpkit/model.py
+++ b/gpkit/model.py
@@ -1,5 +1,6 @@
 "Implements Model"
 
+from time import time
 import numpy as np
 
 from .constraints.costed import CostedConstraintSet
@@ -171,6 +172,8 @@ class Model(CostedConstraintSet):
             raise ValueError(f"sweepvals has mismatched lengths {lengths}")
         (nsweep,) = lengths
         oldsubs = self.substitutions
+        verbosity = solveargs.get("verbosity", 1)
+        tic = time()
         for i in range(nsweep):
             self.substitutions.update({var: vals[i] for var, vals in sweepvals.items()})
             try:
@@ -196,6 +199,10 @@ class Model(CostedConstraintSet):
             unique_vals = set(val)
             if len(unique_vals) == 1:
                 sols["constants"][key] = unique_vals
+
+        if verbosity > 0:
+            soltime = time() - tic
+            print(f"Sweeping took {soltime:.3g} seconds.")
 
         sols.to_arrays()
         sols.modelstr = str(self)

--- a/gpkit/model.py
+++ b/gpkit/model.py
@@ -171,11 +171,9 @@ class Model(CostedConstraintSet):
         lengths = {len(vals) for vals in sweepvals.values()}
         if len(lengths) != 1:
             raise ValueError(f"sweepvals has mismatched lengths {lengths}")
-        (nsweep,) = lengths
         oldsubs = self.substitutions
-        verbosity = solveargs.get("verbosity", 1)
         tic = time()
-        for i in range(nsweep):
+        for i in range(lengths.pop()):
             self.substitutions.update({var: vals[i] for var, vals in sweepvals.items()})
             try:
                 solvefn(**solveargs)
@@ -197,13 +195,11 @@ class Model(CostedConstraintSet):
                 del sols["constants"][cleankey]
         # all remaining constants should be squashed
         for key, val in sols["constants"].items():
-            unique_vals = set(val)
-            if len(unique_vals) == 1:
-                sols["constants"][key] = unique_vals
+            if len(set(val)) == 1:
+                sols["constants"][key] = set(val)
 
-        if verbosity > 0:
-            soltime = time() - tic
-            print(f"Sweeping took {soltime:.3g} seconds.")
+        if solveargs.get("verbosity", 1) > 0:
+            print(f"Sweeping took {time() - tic:.3g} seconds.")
 
         sols.to_arrays()
         sols.modelstr = str(self)

--- a/gpkit/model.py
+++ b/gpkit/model.py
@@ -145,11 +145,11 @@ class Model(CostedConstraintSet):
         sols = []
         for sweepvar, sweepvals in sweeps.items():
             original_val = self.substitutions.get(sweepvar, None)
-            self.substitutions.update({sweepvar: ("sweep", sweepvals)})
+            sweepdict = {sweepvar: sweepvals}
             try:
-                sols.append(self.solve(**solveargs))
+                sols.append(self.solve(sweep=sweepdict, **solveargs))
             except InvalidGPConstraint:
-                sols.append(self.localsolve(**solveargs))
+                sols.append(self.localsolve(sweep=sweepdict, **solveargs))
             if original_val:
                 self.substitutions[sweepvar] = original_val
             else:

--- a/gpkit/model.py
+++ b/gpkit/model.py
@@ -1,6 +1,7 @@
 "Implements Model"
 
 from time import time
+
 import numpy as np
 
 from .constraints.costed import CostedConstraintSet

--- a/gpkit/nomials/__init__.py
+++ b/gpkit/nomials/__init__.py
@@ -13,7 +13,6 @@ from .math import (
     SignomialInequality,
     SingleSignomialEquality,
 )
-from .substitution import parse_subs
 from .variables import ArrayVariable, Variable, VectorizableVariable
 
 VectorVariable = ArrayVariable

--- a/gpkit/nomials/data.py
+++ b/gpkit/nomials/data.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from ..util.repr_conventions import ReprMixin
 from ..varkey import VarKey
+from ..varmap import VarSet
 
 
 class NomialData(ReprMixin):
@@ -51,7 +52,7 @@ class NomialData(ReprMixin):
     @property
     def vks(self):
         "Set of a NomialData's varkeys, created as necessary."
-        vks = set()
+        vks = VarSet()
         for exp in self.hmap:
             vks.update(exp)
         return vks

--- a/gpkit/nomials/map.py
+++ b/gpkit/nomials/map.py
@@ -7,7 +7,7 @@ import numpy as np
 from .. import units
 from ..units import DimensionalityError, qty
 from ..util.small_classes import EMPTY_HV, HashVector, Strings
-from .substitution import new_parse_subs
+from .substitution import parse_subs
 
 DIMLESS_QUANTITY = qty("dimensionless")
 
@@ -106,7 +106,7 @@ class NomialMap(HashVector):
         if parsedsubs or not substitutions:
             fixed = substitutions
         else:
-            fixed = new_parse_subs(varkeys, substitutions)
+            fixed = parse_subs(varkeys, substitutions)
         if not fixed:
             if not self.expmap:
                 self.expmap, self.csmap = {exp: exp for exp in self}, {}

--- a/gpkit/nomials/map.py
+++ b/gpkit/nomials/map.py
@@ -7,7 +7,7 @@ import numpy as np
 from .. import units
 from ..units import DimensionalityError, qty
 from ..util.small_classes import EMPTY_HV, HashVector, Strings
-from .substitution import parse_subs
+from .substitution import new_parse_subs
 
 DIMLESS_QUANTITY = qty("dimensionless")
 
@@ -106,8 +106,7 @@ class NomialMap(HashVector):
         if parsedsubs or not substitutions:
             fixed = substitutions
         else:
-            fixed, _, _ = parse_subs(varkeys, substitutions)
-
+            fixed = new_parse_subs(varkeys, substitutions)
         if not fixed:
             if not self.expmap:
                 self.expmap, self.csmap = {exp: exp for exp in self}, {}

--- a/gpkit/nomials/math.py
+++ b/gpkit/nomials/math.py
@@ -16,9 +16,9 @@ from ..units import DimensionalityError
 from ..util.small_classes import EMPTY_HV, HashVector, Numbers
 from ..util.small_scripts import mag
 from ..varkey import VarKey
+from ..varmap import VarSet
 from .core import Nomial
 from .map import NomialMap
-from .substitution import parse_subs
 
 
 class Signomial(Nomial):
@@ -123,7 +123,7 @@ class Signomial(Nomial):
         -------
         Monomial (unless self(x0) < 0, in which case a Signomial is returned)
         """
-        x0, _, _ = parse_subs(self.vks, x0)  # use only varkey keys
+        x0 = self.vks.clean(x0)
         psub = self.hmap.sub(x0, self.vks, parsedsubs=True)
         if EMPTY_HV not in psub or len(psub) > 1:
             raise ValueError(
@@ -387,7 +387,7 @@ class ScalarSingleEquationConstraint(SingleEquationConstraint):
 
     def __init__(self, left, oper, right):
         lr = [left, right]
-        self.vks = set()
+        self.vks = VarSet()
         for i, sig in enumerate(lr):
             if isinstance(sig, Signomial):
                 for exp in sig.hmap:
@@ -484,11 +484,10 @@ class PosynomialInequality(ScalarSingleEquationConstraint):
         hmap = self._simplify_posy_ineq(hmap)
         return [Posynomial(hmap)] if hmap else []
 
-    def as_hmapslt1(self, substitutions):
+    def as_hmapslt1(self, fixed):
         "Returns the posys <= 1 representation of this constraint."
         out = []
         for posy in self.unsubbed:
-            fixed, _, _ = parse_subs(posy.vks, substitutions, clean=True)
             hmap = posy.hmap.sub(fixed, posy.vks, parsedsubs=True)
             self.pmap = hmap.mmap(
                 posy.hmap

--- a/gpkit/nomials/math.py
+++ b/gpkit/nomials/math.py
@@ -484,20 +484,20 @@ class PosynomialInequality(ScalarSingleEquationConstraint):
         hmap = self._simplify_posy_ineq(hmap)
         return [Posynomial(hmap)] if hmap else []
 
-    def as_hmapslt1(self, fixed):
+    def as_hmapslt1(self, substitutions):
         "Returns the posys <= 1 representation of this constraint."
         out = []
         for posy in self.unsubbed:
-            hmap = posy.hmap.sub(fixed, posy.vks, parsedsubs=True)
+            hmap = posy.hmap.sub(substitutions, posy.vks, parsedsubs=True)
             self.pmap = hmap.mmap(
                 posy.hmap
             )  # pylint: disable=attribute-defined-outside-init
             del hmap.expmap, hmap.csmap  # needed only for the mmap call above
-            hmap = self._simplify_posy_ineq(hmap, self.pmap, fixed)
+            hmap = self._simplify_posy_ineq(hmap, self.pmap, substitutions)
             if hmap is not None:
                 if any(c <= 0 for c in hmap.values()):
                     raise InvalidGPConstraint(
-                        f"'{self}' became Signomial after substituting {fixed}"
+                        f"'{self}' became Signomial after substituting {substitutions}"
                     )
                 hmap.parent = self
                 out.append(hmap)

--- a/gpkit/nomials/substitution.py
+++ b/gpkit/nomials/substitution.py
@@ -8,7 +8,8 @@ from ..varmap import VarSet
 
 
 def parse_subs(varkeys, substitutions):
-    out = dict()
+    "Return constant mappings {VarKey: val} w/ broadcasting and shape checks."
+    out = {}
     if not isinstance(varkeys, VarSet):
         raise NotImplementedError
     for var, val in substitutions.items():
@@ -33,7 +34,8 @@ def parse_subs(varkeys, substitutions):
 
 
 def parse_sweep(varkeys, sweeps):
-    out = dict()
+    "Validate and return {VarKey: iterable} mapping for synchronized sweeps."
+    out = {}
     if not sweeps:
         return {}
     for var, val in sweeps.items():
@@ -70,7 +72,8 @@ def parse_sweep(varkeys, sweeps):
 
 
 def parse_linked(varkeys, substitutions):
-    out = dict()
+    "Extract linked-sweep callables and return {VarKey: function} mapping."
+    out = {}
     for var, val in substitutions.items():
         for key in varkeys.keys(var):
             if hasattr(val, "__call__") and not hasattr(val, "key"):

--- a/gpkit/nomials/substitution.py
+++ b/gpkit/nomials/substitution.py
@@ -4,11 +4,10 @@ import warnings as pywarnings
 
 import numpy as np
 
-from ..util.small_scripts import splitsweep
 from ..varmap import VarSet
 
 
-def new_parse_subs(varkeys, substitutions):
+def parse_subs(varkeys, substitutions):
     out = dict()
     if not isinstance(varkeys, VarSet):
         raise NotImplementedError
@@ -17,6 +16,9 @@ def new_parse_subs(varkeys, substitutions):
             # cast for shape and lookup by idx
             val = np.array(val) if not hasattr(val, "units") else val
             # else case is pint bug: Quantity's have __len__ but len() raises
+        if hasattr(val, "__call__") and not hasattr(val, "key"):
+            # linked case -- eventually make explicit instead of using subs
+            continue
         for key in varkeys.keys(var):
             if key.shape and getattr(val, "shape", None):
                 if key.shape == val.shape:
@@ -30,73 +32,47 @@ def new_parse_subs(varkeys, substitutions):
     return out
 
 
-def parse_subs(varkeys, substitutions, clean=False):
-    "Seperates subs into the constants, sweeps, linkedsweeps actually present."
-    constants, sweep, linkedsweep = {}, {}, {}
-    if clean:
-        for var in varkeys:
-            if dict.__contains__(substitutions, var):
-                sub = dict.__getitem__(substitutions, var)
-                append_sub(sub, [var], constants, sweep, linkedsweep)
-    else:
-        if not isinstance(varkeys, VarSet):
-            varkeys = VarSet(varkeys)
-        for var in substitutions:
-            key = getattr(var, "key", var)
-            if key in varkeys:
-                sub, keys = substitutions[var], varkeys.keys(key)
-                append_sub(sub, keys, constants, sweep, linkedsweep)
-    return constants, sweep, linkedsweep
-
-
-def append_sub(sub, keys, constants, sweep, linkedsweep):
-    # pylint: disable=too-many-branches
-    "Appends sub to constants, sweep, or linkedsweep."
-    sweepsub, sweepval = splitsweep(sub)
-    if sweepsub:  # if the whole key is swept
-        sub = sweepval
-    for key in keys:
-        if not key.shape or not getattr(sub, "shape", hasattr(sub, "__len__")):
-            value = sub
-        else:
+def parse_sweep(varkeys, sweeps):
+    out = dict()
+    if not sweeps:
+        return {}
+    for var, val in sweeps.items():
+        keys = varkeys.keys(var)
+        for key in keys:
+            if not key.shape:
+                out[key] = val
+                continue
             with pywarnings.catch_warnings():
                 pywarnings.filterwarnings("error")
                 try:
-                    sub = np.array(sub) if not hasattr(sub, "shape") else sub
+                    val = np.array(val) if not hasattr(val, "shape") else val
                 # pylint: disable=fixme
                 except ValueError:  # pragma: no cover  # TODO: coverage this
                     # ragged nested sequences, eg [[2]], [3, 4]], in py3.7+
-                    sub = np.array(sub, dtype=object)
-            if key.shape == sub.shape:
-                value = sub[key.idx]
-                if sweepsub and np.prod(key.shape) != len(keys):
-                    value = sub  # handle coincidental length match case
-                sweepel, sweepval = splitsweep(value)
-                if sweepel:  # if only an element is swept
-                    value = sweepval
-                    sweepsub = True
-            elif sweepsub:
-                try:
-                    np.broadcast(sub, np.empty(key.shape))
-                except ValueError as exc:
-                    raise ValueError(
-                        f"cannot sweep variable {key.veckey} of shape {key.shape}"
-                        f" with array of shape {sub.shape}; array shape"
-                        f" must either be {key.shape} or {('N',) + key.shape}"
-                    ) from exc
-                idx = (slice(None),) + key.descr["idx"]
-                value = sub[idx]
-            else:
-                raise ValueError(
-                    f"cannot substitute array of shape {sub.shape} for"
-                    f" variable {key.veckey} of shape {key.shape}."
-                )
-        if hasattr(value, "__call__") and not hasattr(value, "key"):
-            linkedsweep[key] = value
-        elif sweepsub:
-            sweep[key] = value
-        else:
+                    val = np.array(val, dtype=object)
+            if key.shape == val.shape:
+                # this silly case goes away once standard sweep lens enforced
+                value = val if np.prod(key.shape) != len(keys) else val[key.idx]
+                # handles coincidental length match case
+                out[key] = value
+                continue
             try:
-                assert np.isnan(value)
-            except (AssertionError, TypeError, ValueError):
-                constants[key] = value
+                np.broadcast(val, np.empty(key.shape))
+            except ValueError as exc:
+                raise ValueError(
+                    f"cannot sweep variable {key.veckey} of shape {key.shape}"
+                    f" with array of shape {val.shape}; array shape"
+                    f" must either be {key.shape} or {('N',) + key.shape}"
+                ) from exc
+            idx = (slice(None),) + key.descr["idx"]
+            out[key] = val[idx]
+    return out
+
+
+def parse_linked(varkeys, substitutions):
+    out = dict()
+    for var, val in substitutions.items():
+        for key in varkeys.keys(var):
+            if hasattr(val, "__call__") and not hasattr(val, "key"):
+                out[key] = val
+    return out

--- a/gpkit/nomials/variables.py
+++ b/gpkit/nomials/variables.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from ..globals import NamedVariables, Vectorize
 from ..util.small_classes import HashVector, Numbers, Strings
-from ..util.small_scripts import is_sweepvar, veclinkedfn
+from ..util.small_scripts import veclinkedfn
 from ..varkey import VarKey
 from .array import NomialArray
 from .data import NomialData
@@ -29,7 +29,7 @@ class Variable(Monomial):
     ---------
     *args : list
         may contain "name" (Strings)
-                    "value" (Numbers + Quantity) or (Iterable) for a sweep
+                    "value" (Numbers + Quantity)
                     "units" (Strings)
              and/or "label" (Strings)
     **descr : dict
@@ -55,10 +55,7 @@ class Variable(Monomial):
                 ):
                     descr["value"] = arg
                 elif isinstance(arg, Iterable) and not isinstance(arg, Strings):
-                    if is_sweepvar(arg):
-                        descr["value"] = arg
-                    else:
-                        descr["value"] = ("sweep", arg)
+                    raise NotImplementedError
                 elif isinstance(arg, Strings) and "units" not in descr:
                     descr["units"] = arg
                 elif isinstance(arg, Strings) and "label" not in descr:

--- a/gpkit/programs/prog_factories.py
+++ b/gpkit/programs/prog_factories.py
@@ -110,9 +110,7 @@ def progify(program, return_attr=None):
 def solvify(genfunction):
     "Returns function for making/solving/sweeping a program."
 
-    def solvefn(
-        self, solver=None, *, verbosity=1, sweep=None, skipsweepfailures=False, **kwargs
-    ):
+    def solvefn(self, solver=None, *, verbosity=1, skipsweepfailures=False, **kwargs):
         """Forms a mathematical program and attempts to solve it.
 
         Arguments
@@ -137,7 +135,8 @@ def solvify(genfunction):
         RuntimeWarning if an error occurs in solving or parsing the solution.
         """
         constants = parse_subs(self.varkeys, self.substitutions)
-        sweep = parse_sweep(self.varkeys, sweep)
+        sweep = parse_sweep(self.varkeys, None)
+        assert not sweep
         linked = parse_linked(self.varkeys, self.substitutions)
         solution = SolutionArray()
         solution.modelstr = str(self)

--- a/gpkit/programs/prog_factories.py
+++ b/gpkit/programs/prog_factories.py
@@ -8,7 +8,7 @@ from adce import adnumber
 
 from ..exceptions import Infeasible
 from ..globals import SignomialsEnabled
-from ..nomials import parse_subs
+from ..nomials.substitution import parse_linked, parse_subs, parse_sweep
 from ..solution_array import SolutionArray
 from ..util.small_classes import FixedScalar
 from ..util.small_scripts import maybe_flatten
@@ -94,7 +94,8 @@ def progify(program, return_attr=None):
     def programfn(self, constants=None, **initargs):
         "Return program version of self"
         if not constants:
-            constants, _, linked = parse_subs(self.varkeys, self.substitutions)
+            constants = parse_subs(self.varkeys, self.substitutions)
+            linked = parse_linked(self.varkeys, self.substitutions)
             if linked:
                 evaluate_linked(constants, linked)
         prog = program(self.cost, self, constants, **initargs)
@@ -109,7 +110,9 @@ def progify(program, return_attr=None):
 def solvify(genfunction):
     "Returns function for making/solving/sweeping a program."
 
-    def solvefn(self, solver=None, *, verbosity=1, skipsweepfailures=False, **kwargs):
+    def solvefn(
+        self, solver=None, *, verbosity=1, sweep=None, skipsweepfailures=False, **kwargs
+    ):
         """Forms a mathematical program and attempts to solve it.
 
         Arguments
@@ -133,7 +136,9 @@ def solvify(genfunction):
         ValueError if the program is invalid.
         RuntimeWarning if an error occurs in solving or parsing the solution.
         """
-        constants, sweep, linked = parse_subs(self.varkeys, self.substitutions)
+        constants = parse_subs(self.varkeys, self.substitutions)
+        sweep = parse_sweep(self.varkeys, sweep)
+        linked = parse_linked(self.varkeys, self.substitutions)
         solution = SolutionArray()
         solution.modelstr = str(self)
 

--- a/gpkit/programs/prog_factories.py
+++ b/gpkit/programs/prog_factories.py
@@ -1,14 +1,12 @@
 "Scripts for generating, solving and sweeping programs"
 
 import warnings as pywarnings
-from time import time
 
 import numpy as np
 from adce import adnumber
 
-from ..exceptions import Infeasible
 from ..globals import SignomialsEnabled
-from ..nomials.substitution import parse_linked, parse_subs, parse_sweep
+from ..nomials.substitution import parse_linked, parse_subs
 from ..solution_array import SolutionArray
 from ..util.small_classes import FixedScalar
 from ..util.small_scripts import maybe_flatten
@@ -110,7 +108,7 @@ def progify(program, return_attr=None):
 def solvify(genfunction):
     "Returns function for making/solving/sweeping a program."
 
-    def solvefn(self, solver=None, *, verbosity=1, skipsweepfailures=False, **kwargs):
+    def solvefn(self, solver=None, *, verbosity=1, **kwargs):
         """Forms a mathematical program and attempts to solve it.
 
         Arguments
@@ -120,8 +118,6 @@ def solvify(genfunction):
         verbosity : int (default 1)
             If greater than 0 prints runtime messages.
             Is decremented by one and then passed to programs.
-        skipsweepfailures : bool (default False)
-            If True, when a solve errors during a sweep, skip it.
         **kwargs : Passed to solve and program init calls
 
         Returns
@@ -134,136 +130,17 @@ def solvify(genfunction):
         ValueError if the program is invalid.
         RuntimeWarning if an error occurs in solving or parsing the solution.
         """
-        constants = parse_subs(self.varkeys, self.substitutions)
-        sweep = parse_sweep(self.varkeys, None)
-        assert not sweep
-        linked = parse_linked(self.varkeys, self.substitutions)
         solution = SolutionArray()
         solution.modelstr = str(self)
 
         # NOTE SIDE EFFECTS: self.program and self.solution set below
-        if sweep:
-            run_sweep(
-                genfunction,
-                self,
-                solution,
-                skipsweepfailures,
-                constants,
-                sweep,
-                linked,
-                solver,
-                verbosity,
-                **kwargs,
-            )
-        else:
-            self.program, progsolve = genfunction(self, **kwargs)
-            result = progsolve(solver, verbosity=verbosity, **kwargs)
-            if kwargs.get("process_result", True):
-                self.process_result(result)
-            solution.append(result)
+        self.program, progsolve = genfunction(self, **kwargs)
+        result = progsolve(solver, verbosity=verbosity, **kwargs)
+        if kwargs.get("process_result", True):
+            self.process_result(result)
+        solution.append(result)
         solution.to_arrays()
         self.solution = solution
         return solution
 
     return solvefn
-
-
-# pylint: disable=too-many-locals,too-many-arguments,too-many-branches
-# pylint: disable=too-many-statements,too-many-positional-arguments
-def run_sweep(
-    genfunction,
-    self,
-    solution,
-    skipsweepfailures,
-    constants,
-    sweep,
-    linked,
-    solver,
-    verbosity,
-    **kwargs,
-):
-    "Runs through a sweep."
-    # sort sweeps by the eqstr of their varkey
-    sweepvars, sweepvals = zip(
-        *sorted(list(sweep.items()), key=lambda vkval: vkval[0].eqstr)
-    )
-    if len(sweep) == 1:
-        sweep_grids = np.array(list(sweepvals))
-    else:
-        sweep_grids = np.meshgrid(*list(sweepvals))
-
-    n_passes = sweep_grids[0].size
-    sweep_vects = {
-        var: grid.reshape(n_passes) for (var, grid) in zip(sweepvars, sweep_grids)
-    }
-
-    if verbosity > 0:
-        tic = time()
-
-    self.program = []
-    last_error = None
-    for i in range(n_passes):
-        constants.update(
-            {var: sweep_vect[i] for (var, sweep_vect) in sweep_vects.items()}
-        )
-        if linked:
-            evaluate_linked(constants, linked)
-        program, solvefn = genfunction(self, constants, **kwargs)
-        program.model = None  # so it doesn't try to debug
-        self.program.append(program)  # NOTE: SIDE EFFECTS
-        if i == 0 and verbosity > 0:  # wait for successful program gen
-            # pylint: disable=fixme
-            # TODO: use full string when minimum lineage is set automatically
-            sweepvarsstr = ", ".join(
-                [
-                    str(var)
-                    for var, val in zip(sweepvars, sweepvals)
-                    if not np.isnan(val).all()
-                ]
-            )
-            print(f"Sweeping {sweepvarsstr} with {n_passes} solves:")
-        try:
-            if verbosity > 1:
-                print(f"\nSolve {i}:")
-            result = solvefn(solver, verbosity=verbosity - 1, **kwargs)
-            if kwargs.get("process_result", True):
-                self.process_result(result)
-            solution.append(result)
-            if verbosity == 1:
-                print(".", end="", flush=True)
-        except Infeasible as e:
-            last_error = e
-            if not skipsweepfailures:
-                raise RuntimeWarning(
-                    f"Solve {i} was infeasible; progress saved to m.program."
-                    " To continue sweeping after failures, solve with"
-                    " skipsweepfailures=True."
-                ) from e
-            if verbosity > 1:
-                print(f"Solve {i} was {e.__class__.__name__}.")
-            if verbosity == 1:
-                print("!", end="", flush=True)
-    if not solution:
-        raise RuntimeWarning("All solves were infeasible.") from last_error
-    if verbosity == 1:
-        print()
-
-    solution["sweepvariables"] = VarMap()
-    ksweep = VarMap(sweep)
-    for var, val in list(solution["constants"].items()):
-        if var in ksweep:
-            solution["sweepvariables"][var] = val
-            del solution["constants"][var]
-        elif linked:  # if any variables are linked, we check all of them
-            if hasattr(val[0], "shape"):
-                differences = ((x != val[0]).any() for x in val[1:])
-            else:
-                differences = (x != val[0] for x in val[1:])
-            if not any(differences):
-                solution["constants"][var] = [val[0]]
-        else:
-            solution["constants"][var] = [val[0]]
-
-    if verbosity > 0:
-        soltime = time() - tic
-        print(f"Sweeping took {soltime:.3g} seconds.")

--- a/gpkit/tests/t_solution_array.py
+++ b/gpkit/tests/t_solution_array.py
@@ -49,7 +49,7 @@ class TestSolutionArray(unittest.TestCase):
         w = Variable("w", "m", "width")
         m = Model(12 / (w * h**3), [h <= h_max, h * w >= a_min, p_max >= 2 * h + 2 * w])
         p_vals = np.linspace(13, 24, 20)
-        sol = m.solve(verbosity=0, sweep={p_max: p_vals})
+        sol = m.sweep({p_max: p_vals}, verbosity=0)
         p_sol = sol.subinto(p_max)
         self.assertEqual(len(p_sol), 20)
         self.assertAlmostEqual(

--- a/gpkit/tests/t_solution_array.py
+++ b/gpkit/tests/t_solution_array.py
@@ -42,17 +42,16 @@ class TestSolutionArray(unittest.TestCase):
             self.assertAlmostEqual(solx[i], 2.5, places=4)
 
     def test_subinto(self):
-        n_sweep = 20
-        p_vals = np.linspace(13, 24, n_sweep)
         h_max = Variable("h_max", 10, "m", "Length")
         a_min = Variable("A_min", 10, "m^2", "Area")
-        p_max = Variable("P", p_vals, "m", "Perimeter")
+        p_max = Variable("P", "m", "Perimeter")
         h = Variable("h", "m", "Length")
         w = Variable("w", "m", "width")
         m = Model(12 / (w * h**3), [h <= h_max, h * w >= a_min, p_max >= 2 * h + 2 * w])
-        sol = m.solve(verbosity=0)
+        p_vals = np.linspace(13, 24, 20)
+        sol = m.solve(verbosity=0, sweep={p_max: p_vals})
         p_sol = sol.subinto(p_max)
-        self.assertEqual(len(p_sol), n_sweep)
+        self.assertEqual(len(p_sol), 20)
         self.assertAlmostEqual(
             0 * gpkit.ureg.m, np.max(np.abs(p_vals * gpkit.ureg.m - p_sol))
         )

--- a/gpkit/tests/t_tools.py
+++ b/gpkit/tests/t_tools.py
@@ -38,8 +38,7 @@ class TestTools(unittest.TestCase):
         w_s = Variable("v_{CO}", lambda c: 1 - c[ws], "-")
         obj = ws * (x + y) + w_s * (y**-1 * x**-3)
         m = Model(obj, eqns)
-        sweep = {ws: np.linspace(1 / n, 1 - 1 / n, n)}
-        sol = m.solve(verbosity=0, sweep=sweep)
+        sol = m.sweep({ws: np.linspace(1 / n, 1 - 1 / n, n)}, verbosity=0)
         a = sol["cost"]
         b = np.array([1.58856898, 2.6410391, 3.69348122, 4.74591386])
         self.assertTrue((abs(a - b) / (a + b + 1e-7) < 1e-7).all())

--- a/gpkit/tests/t_tools.py
+++ b/gpkit/tests/t_tools.py
@@ -34,11 +34,12 @@ class TestTools(unittest.TestCase):
         y = Variable("y")
         eqns = [x >= 1, y >= 1, x * y == 10]
         n = 4
-        ws = Variable("w_{CO}", ("sweep", np.linspace(1 / n, 1 - 1 / n, n)), "-")
+        ws = Variable("w_{CO}")
         w_s = Variable("v_{CO}", lambda c: 1 - c[ws], "-")
         obj = ws * (x + y) + w_s * (y**-1 * x**-3)
         m = Model(obj, eqns)
-        sol = m.solve(verbosity=0)
+        sweep = {ws: np.linspace(1 / n, 1 - 1 / n, n)}
+        sol = m.solve(verbosity=0, sweep=sweep)
         a = sol["cost"]
         b = np.array([1.58856898, 2.6410391, 3.69348122, 4.74591386])
         self.assertTrue((abs(a - b) / (a + b + 1e-7) < 1e-7).all())

--- a/gpkit/tests/t_varset.py
+++ b/gpkit/tests/t_varset.py
@@ -23,6 +23,7 @@ def test_add_and_membership():
     assert x.key in vs
     # membership by canonical name
     assert "x" in vs
+    assert x in vs
     # by_name should return a set *containing* x
     assert vs.by_name("x") == {x.key}
 

--- a/gpkit/util/small_scripts.py
+++ b/gpkit/util/small_scripts.py
@@ -45,21 +45,3 @@ def try_str_without(item, excluded, *, latex=False):
 def mag(c):
     "Return magnitude of a Number or Quantity"
     return getattr(c, "magnitude", c)
-
-
-def is_sweepvar(sub):
-    "Determines if a given substitution indicates a sweep."
-    return splitsweep(sub)[0]
-
-
-def splitsweep(sub):
-    "Splits a substitution into (is_sweepvar, sweepval)"
-    try:
-        sweep, value = sub
-        if sweep == "sweep" and (
-            isinstance(value, Iterable) or hasattr(value, "__call__")
-        ):
-            return True, value
-    except (TypeError, ValueError):
-        pass
-    return False, None

--- a/gpkit/util/small_scripts.py
+++ b/gpkit/util/small_scripts.py
@@ -1,7 +1,5 @@
 """Assorted helper methods"""
 
-from collections.abc import Iterable
-
 
 def veclinkedfn(linkedfn, i):
     "Generate an indexed linking function."

--- a/gpkit/varmap.py
+++ b/gpkit/varmap.py
@@ -148,6 +148,7 @@ class VarSet(set):
             self._by_vec[key.veckey][idx] = key
 
     def __contains__(self, key):
+        key = getattr(key, "key", None) or key  # Variable case
         if super().__contains__(key):
             return True
         return key in self._by_name or key in self._by_vec

--- a/gpkit/varmap.py
+++ b/gpkit/varmap.py
@@ -5,7 +5,7 @@ from collections.abc import MutableMapping
 import numpy as np
 
 from .units import Quantity
-from .util.small_scripts import is_sweepvar, veclinkedfn
+from .util.small_scripts import veclinkedfn
 
 
 def _nested_lookup(nested_keys, val_dict):
@@ -196,9 +196,6 @@ class VarMap(MutableMapping):
         if is_veckey(key):
             if key not in self._varset._by_vec:
                 raise NotImplementedError
-            if is_sweepvar(value):
-                self._data[key] = value
-                return
             if hasattr(value, "__call__"):  # a linked vector-function
                 # this case temporarily borrowed from keymap, should refactor
                 key.vecfn = value


### PR DESCRIPTION
eliminates `("sweep", val)` tuples in favor of an explicit `Model.sweep()` method